### PR TITLE
Add --min-dist option in CLI

### DIFF
--- a/pareidolia/cli/__init__.py
+++ b/pareidolia/cli/__init__.py
@@ -193,7 +193,7 @@ def pareidolia_cmd(
         kernel=kernel,
         bed2d_file=bed2d_file,
         region=region,
-        max_dist=min_dist,
+        min_dist=min_dist,
         max_dist=max_dist,
         subsample=not no_subsample,
         pearson_thresh=pearson,

--- a/pareidolia/cli/__init__.py
+++ b/pareidolia/cli/__init__.py
@@ -45,6 +45,17 @@ from .. import __version__
     ),
 )
 @click.option(
+    "--min-dist",
+    "-m",
+    default=None,
+    show_default=True,
+    help=(
+        "Minimum interaction distance (in basepairs) at which patterns should"
+        " be detected. No lower limit by default."
+    ),
+    type=int,
+)
+@click.option(
     "--max-dist",
     "-M",
     default=None,
@@ -134,6 +145,7 @@ def pareidolia_cmd(
     kernel,
     bed2d_file,
     region,
+    min_dist,
     max_dist,
     no_subsample,
     no_filter,
@@ -181,6 +193,7 @@ def pareidolia_cmd(
         kernel=kernel,
         bed2d_file=bed2d_file,
         region=region,
+        max_dist=min_dist,
         max_dist=max_dist,
         subsample=not no_subsample,
         pearson_thresh=pearson,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,10 @@ def test_change_detection():
         [
             cools,
             conds,
+            "--min-dist",
+            100,
+            "--max-dist",
+            100000,
             "--bed2d-file",
             str(DATA / "B_loops.bed2d"),
             out_f.name,


### PR DESCRIPTION
Expose existing `min_dist` parameter of `change_detection_pipeline` in the CLI as `--min-dist`